### PR TITLE
객체 타입들에 대한 참조를 포인터로 변경

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -4,14 +4,13 @@ import tx "github.com/it-chain/yggdrasill/transaction"
 
 //interface에 맞춰 설계
 //interface를 implement하는 모든 custom block을 사용 가능하게 구현.
-type Block interface{
-	PutTransaction(transaction tx.Transaction)
+type Block interface {
+	PutTransaction(transaction *tx.Transaction)
 	FindTransactionIndexByHash(txHash string)
 	Serialize() ([]byte, error)
 	GenerateHash() error
 	GetHash() string
-	GetTransactions() []tx.Transaction
+	GetTransactions() []*tx.Transaction
 	GetHeight() uint64
 	IsPrev(serializedBlock []byte) bool
 }
-

--- a/block/default_block.go
+++ b/block/default_block.go
@@ -31,21 +31,21 @@ type BlockHeader struct {
 	TransactionCount   int
 }
 
-func (block DefaultBlock) PutTransaction(transaction tx.Transaction) {
+func (block *DefaultBlock) PutTransaction(transaction tx.Transaction) {
 
 	block.Transactions = append(block.Transactions, transaction)
 	block.Header.TransactionCount++
 }
 
-func (block DefaultBlock) FindTransactionIndexByHash(txHash string) {
+func (block *DefaultBlock) FindTransactionIndexByHash(txHash string) {
 
 }
 
-func (block DefaultBlock) Serialize() ([]byte, error) {
+func (block *DefaultBlock) Serialize() ([]byte, error) {
 	return util.Serialize(block)
 }
 
-func (block DefaultBlock) GenerateHash() error {
+func (block *DefaultBlock) GenerateHash() error {
 
 	if block.Header.MerkleTreeRootHash == "" {
 		return errors.New("no merkle tree root hash")
@@ -57,19 +57,19 @@ func (block DefaultBlock) GenerateHash() error {
 	return nil
 }
 
-func (block DefaultBlock) GetHash() string {
+func (block *DefaultBlock) GetHash() string {
 	return block.Header.BlockHash
 }
 
-func (block DefaultBlock) GetTransactions() []tx.Transaction {
+func (block *DefaultBlock) GetTransactions() []tx.Transaction {
 	return block.Transactions
 }
 
-func (block DefaultBlock) GetHeight() uint64 {
+func (block *DefaultBlock) GetHeight() uint64 {
 	return block.Header.Height
 }
 
-func (block DefaultBlock) IsPrev(serializedBlock []byte) bool {
+func (block *DefaultBlock) IsPrev(serializedBlock []byte) bool {
 	return true
 }
 

--- a/block/default_block.go
+++ b/block/default_block.go
@@ -15,7 +15,7 @@ import (
 type DefaultBlock struct {
 	Header       BlockHeader
 	MerkleTree   [][]string
-	Transactions []tx.Transaction
+	Transactions []*tx.Transaction
 }
 
 type BlockHeader struct {
@@ -31,7 +31,7 @@ type BlockHeader struct {
 	TransactionCount   int
 }
 
-func (block *DefaultBlock) PutTransaction(transaction tx.Transaction) {
+func (block *DefaultBlock) PutTransaction(transaction *tx.Transaction) {
 
 	block.Transactions = append(block.Transactions, transaction)
 	block.Header.TransactionCount++
@@ -61,7 +61,7 @@ func (block *DefaultBlock) GetHash() string {
 	return block.Header.BlockHash
 }
 
-func (block *DefaultBlock) GetTransactions() []tx.Transaction {
+func (block *DefaultBlock) GetTransactions() []*tx.Transaction {
 	return block.Transactions
 }
 

--- a/block/default_block.go
+++ b/block/default_block.go
@@ -13,7 +13,7 @@ import (
 )
 
 type DefaultBlock struct {
-	Header       BlockHeader
+	Header       *BlockHeader
 	MerkleTree   [][]string
 	Transactions []*tx.Transaction
 }


### PR DESCRIPTION
객체 타입(`struct`)들에 대한 참조를 객체 자체를 copy by value하는 것에서 포인터 참조로 모두 변경.