### PR TITLE
Renaming yggdrasil -> yggdrasill

### DIFF
--- a/yggdrasill.go
+++ b/yggdrasill.go
@@ -18,27 +18,27 @@ const (
 	LAST_BLOCK_KEY  = "last_block"
 )
 
-type Yggdrasil struct {
+type Yggdrasill struct {
 	DBProvider *DBProvider
 	validator  validator.Validator
 }
 
-func NewYggdrasil(keyValueDB key_value_db.KeyValueDB, validator validator.Validator, opts map[string]interface{}) *Yggdrasil {
+func NewYggdrasill(keyValueDB key_value_db.KeyValueDB, validator validator.Validator, opts map[string]interface{}) *Yggdrasill {
 
 	dbProvider := CreateNewDBProvider(keyValueDB)
 
-	return &Yggdrasil{DBProvider: dbProvider, validator: validator}
+	return &Yggdrasill{DBProvider: dbProvider, validator: validator}
 }
 
-func (y *Yggdrasil) Close() {
+func (y *Yggdrasill) Close() {
 	y.DBProvider.Close()
 }
 
-func (y *Yggdrasil) createGenesisBlock() {
+func (y *Yggdrasill) createGenesisBlock() {
 
 }
 
-func (y *Yggdrasil) AddBlock(block block.Block) error {
+func (y *Yggdrasill) AddBlock(block block.Block) error {
 	utilDB := y.DBProvider.GetDBHandle(UTIL_DB)
 	lastBlock, err := utilDB.Get([]byte(LAST_BLOCK_KEY))
 
@@ -94,7 +94,7 @@ func (y *Yggdrasil) AddBlock(block block.Block) error {
 	return nil
 }
 
-func (y *Yggdrasil) GetBlockByNumber(block block.Block, blockNumber uint64) error {
+func (y *Yggdrasill) GetBlockByNumber(block block.Block, blockNumber uint64) error {
 	blockNumberDB := y.DBProvider.GetDBHandle(BLOCK_NUMBER_DB)
 
 	blockHash, err := blockNumberDB.Get([]byte(fmt.Sprint(blockNumber)))
@@ -105,7 +105,7 @@ func (y *Yggdrasil) GetBlockByNumber(block block.Block, blockNumber uint64) erro
 	return y.GetBlockByHash(block, string(blockHash))
 }
 
-func (y *Yggdrasil) GetBlockByHash(block block.Block, hash string) error {
+func (y *Yggdrasill) GetBlockByHash(block block.Block, hash string) error {
 	blockHashDB := y.DBProvider.GetDBHandle(BLOCK_HASH_DB)
 
 	serializedBlock, err := blockHashDB.Get([]byte(hash))
@@ -118,7 +118,7 @@ func (y *Yggdrasil) GetBlockByHash(block block.Block, hash string) error {
 	return err
 }
 
-func (y *Yggdrasil) GetLastBlock(block block.Block) error {
+func (y *Yggdrasill) GetLastBlock(block block.Block) error {
 	utilDB := y.DBProvider.GetDBHandle(UTIL_DB)
 
 	serializedBlock, err := utilDB.Get([]byte(LAST_BLOCK_KEY))
@@ -131,7 +131,7 @@ func (y *Yggdrasil) GetLastBlock(block block.Block) error {
 	return err
 }
 
-func (y *Yggdrasil) GetTransactionByTxID(transaction transaction.Transaction, txid string) error {
+func (y *Yggdrasill) GetTransactionByTxID(transaction transaction.Transaction, txid string) error {
 	transactionDB := y.DBProvider.GetDBHandle(TRANSACTION_DB)
 
 	serializedTX, err := transactionDB.Get([]byte(txid))
@@ -144,7 +144,7 @@ func (y *Yggdrasil) GetTransactionByTxID(transaction transaction.Transaction, tx
 	return err
 }
 
-func (y *Yggdrasil) GetBlockByTxID(block block.Block, txid string) error {
+func (y *Yggdrasill) GetBlockByTxID(block block.Block, txid string) error {
 	utilDB := y.DBProvider.GetDBHandle(UTIL_DB)
 
 	blockHash, err := utilDB.Get([]byte(txid))

--- a/yggdrasill_test.go
+++ b/yggdrasill_test.go
@@ -20,7 +20,7 @@ func TestYggDrasill_AddBlock(t *testing.T) {
 	}
 
 	db := leveldbwrapper.CreateNewDB(dbPath)
-	y := NewYggdrasil(db, nil, opts)
+	y := NewYggdrasill(db, nil, opts)
 	defer func() {
 		y.Close()
 		os.RemoveAll(dbPath)
@@ -56,7 +56,7 @@ func TestYggDrasill_AddBlock2(t *testing.T) {
 	}
 
 	db := leveldbwrapper.CreateNewDB(dbPath)
-	y := NewYggdrasil(db, nil, opts)
+	y := NewYggdrasill(db, nil, opts)
 
 	defer func() {
 		y.Close()
@@ -81,7 +81,7 @@ func TestYggdrasil_GetBlockByNumber(t *testing.T) {
 	}
 
 	db := leveldbwrapper.CreateNewDB(dbPath)
-	y := NewYggdrasil(db, nil, opts)
+	y := NewYggdrasill(db, nil, opts)
 	defer func() {
 		y.Close()
 		os.RemoveAll(dbPath)
@@ -115,7 +115,7 @@ func TestYggdrasil_GetBlockByHash(t *testing.T) {
 	}
 
 	db := leveldbwrapper.CreateNewDB(dbPath)
-	y := NewYggdrasil(db, nil, opts)
+	y := NewYggdrasill(db, nil, opts)
 	defer func() {
 		y.Close()
 		os.RemoveAll(dbPath)
@@ -149,7 +149,7 @@ func TestYggdrasil_GetLastBlock(t *testing.T) {
 	}
 
 	db := leveldbwrapper.CreateNewDB(dbPath)
-	y := NewYggdrasil(db, nil, opts)
+	y := NewYggdrasill(db, nil, opts)
 	defer func() {
 		y.Close()
 		os.RemoveAll(dbPath)
@@ -182,7 +182,7 @@ func TestYggdrasil_GetTransactionByTxID(t *testing.T) {
 	}
 
 	db := leveldbwrapper.CreateNewDB(dbPath)
-	y := NewYggdrasil(db, nil, opts)
+	y := NewYggdrasill(db, nil, opts)
 	defer func() {
 		y.Close()
 		os.RemoveAll(dbPath)
@@ -214,7 +214,7 @@ func TestYggdrasil_GetBlockByTxID(t *testing.T) {
 	}
 
 	db := leveldbwrapper.CreateNewDB(dbPath)
-	y := NewYggdrasil(db, nil, opts)
+	y := NewYggdrasill(db, nil, opts)
 	defer func() {
 		y.Close()
 		os.RemoveAll(dbPath)


### PR DESCRIPTION
yggdrasil의 l이 1개이길래 2개로 모두 변경했습니다.
찾아보니까 l이 1개든 2개든 모두 위그드라실을 의미하긴하는데, 우리 저장소가 l 2개 이므로, l 2개로 바꾸었습니다.

.. 리뷰가 필요할까 싶은데, 일단 테스트는 안 깨지니 쓱~ 편하게 살펴보시기 바랍니다.