### PR TITLE
junk-sound:Changed roothash

### DIFF
--- a/impl/default_block_test.go
+++ b/impl/default_block_test.go
@@ -16,14 +16,11 @@ func TestNewEmptyBlock(t *testing.T) {
 
 func TestSerializeAndDeserialize(t *testing.T) {
 	block := getNewBlock()
-
 	serializedBlock, err := block.Serialize()
 	assert.NoError(t, err)
-
 	deserializedBlock := &DefaultBlock{}
 	err = deserializedBlock.Deserialize(serializedBlock)
 	assert.NoError(t, err)
-
 	assert.Equal(t, deserializedBlock, block)
 }
 
@@ -33,7 +30,6 @@ func getNewBlock() *DefaultBlock {
 	blockCreator := []byte("testUser")
 	genesisSeal := []byte("genesis")
 	txList := getTestingTxList(0)
-
 	block := NewEmptyBlock(genesisSeal, 0, blockCreator)
 	block.SetTimestamp(testingTime)
 	for _, tx := range txList {

--- a/impl/default_validator.go
+++ b/impl/default_validator.go
@@ -15,11 +15,12 @@ type DefaultValidator struct{}
 
 // ValidateSeal 함수는 원래 Seal 값과 주어진 Seal 값(comparisonSeal)을 비교하여, 올바른지 검증한다.
 func (t *DefaultValidator) ValidateSeal(seal []byte, comparisonBlock common.Block) (bool, error) {
+
 	comparisonSeal, error := t.BuildSeal(comparisonBlock)
+
 	if error != nil {
 		return false, error
 	}
-
 	return bytes.Compare(seal, comparisonSeal) == 0, nil
 }
 
@@ -107,13 +108,18 @@ func (t *DefaultValidator) BuildSeal(block common.Block) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	prevSeal, txListSeal, creator := block.GetPrevSeal(), block.GetTxSeal(), block.GetCreator()
 
 	if prevSeal == nil || txListSeal == nil || creator == nil {
 		return nil, common.ErrInsufficientFields
 	}
-
-	rootHash := txListSeal[0]
+	var rootHash []byte
+	if len(txListSeal) == 0 {
+		rootHash = make([]byte, 0)
+	} else {
+		rootHash = txListSeal[0]
+	}
 	combined := append(prevSeal, rootHash...)
 	combined = append(combined, timestamp...)
 

--- a/impl/util.go
+++ b/impl/util.go
@@ -12,6 +12,12 @@ func calculateHash(b []byte) []byte {
 	return hashValue.Sum(nil)
 }
 
+func CalculateHash(b []byte) []byte {
+	hashValue := sha256.New()
+	hashValue.Write(b)
+	return hashValue.Sum(nil)
+}
+
 func convertType(txList []*DefaultTransaction) []common.Transaction {
 	convTxList := make([]common.Transaction, 0)
 	for _, tx := range txList {

--- a/impl/util.go
+++ b/impl/util.go
@@ -12,12 +12,6 @@ func calculateHash(b []byte) []byte {
 	return hashValue.Sum(nil)
 }
 
-func CalculateHash(b []byte) []byte {
-	hashValue := sha256.New()
-	hashValue.Write(b)
-	return hashValue.Sum(nil)
-}
-
 func convertType(txList []*DefaultTransaction) []common.Transaction {
 	convTxList := make([]common.Transaction, 0)
 	for _, tx := range txList {

--- a/yggdrasill.go
+++ b/yggdrasill.go
@@ -59,7 +59,6 @@ func (y *Yggdrasill) AddBlock(block common.Block) error {
 	blockSealDB := y.DBProvider.GetDBHandle(blockSealDB)
 	blockHeightDB := y.DBProvider.GetDBHandle(blockHeightDB)
 	transactionDB := y.DBProvider.GetDBHandle(transactionDB)
-
 	err = blockSealDB.Put(block.GetSeal(), serializedBlock, true)
 	if err != nil {
 		return err
@@ -173,15 +172,12 @@ func (y *Yggdrasill) validateBlock(block common.Block) error {
 	if err != nil {
 		return err
 	}
-
-	// Check if the new block has a correct pointer to the last block
 	if lastBlockByte != nil && !block.IsPrev(lastBlockByte) {
 		return ErrPrevSealMismatch
 	}
 
 	// Validate the Seal of the new block using the validator
 	result, err := y.validator.ValidateSeal(block.GetSeal(), block)
-
 	if err != nil {
 		return err
 	}

--- a/yggdrasill_test.go
+++ b/yggdrasill_test.go
@@ -7,8 +7,6 @@ import (
 
 	"time"
 
-	"fmt"
-
 	"github.com/it-chain/leveldb-wrapper"
 	"github.com/it-chain/yggdrasill/common"
 	"github.com/it-chain/yggdrasill/impl"
@@ -58,8 +56,6 @@ func TestYggdrasill_AddBlock_OneBlock(t *testing.T) {
 	assert.Equal(t, uint64(0), lastBlock.GetHeight())
 	assert.Equal(t, []byte("testUser"), lastBlock.GetCreator())
 	assert.Equal(t, "tx01", lastBlock.GetTxList()[0].GetID())
-
-	//fmt.Print(lastBlock)
 }
 
 func TestYggdrasill_AddBlock_TwoBlocks(t *testing.T) {
@@ -298,9 +294,6 @@ func TestYggdrasil_GetBlockByTxID(t *testing.T) {
 	}()
 
 	firstBlock := getNewBlock([]byte("genesis"), 0)
-	fmt.Println("firstblock")
-	fmt.Println(firstBlock.PrevSeal)
-
 	err = y.AddBlock(firstBlock)
 	assert.NoError(t, err)
 
@@ -317,19 +310,13 @@ func TestYggdrasil_GetBlockByTxID(t *testing.T) {
 func getNewBlock(prevSeal []byte, height uint64) *impl.DefaultBlock {
 	validator := &impl.DefaultValidator{}
 	testingTime := getTime()
-	fmt.Println("testingTime:")
-	fmt.Println(testingTime)
 	blockCreator := []byte("testUser")
 	txList := getTxList(testingTime)
-	fmt.Println("Debugging")
-	fmt.Println(txList)
-
 	block := impl.NewEmptyBlock(prevSeal, height, blockCreator)
 	block.SetTimestamp(testingTime)
 	for _, tx := range txList {
 		block.PutTx(tx)
 	}
-
 	txSeal, _ := validator.BuildTxSeal(convertTxListType(txList))
 	block.SetTxSeal(txSeal)
 

--- a/yggdrasill_test.go
+++ b/yggdrasill_test.go
@@ -7,6 +7,8 @@ import (
 
 	"time"
 
+	"fmt"
+
 	"github.com/it-chain/leveldb-wrapper"
 	"github.com/it-chain/yggdrasill/common"
 	"github.com/it-chain/yggdrasill/impl"
@@ -43,6 +45,7 @@ func TestYggdrasill_AddBlock_OneBlock(t *testing.T) {
 	}()
 
 	firstBlock := getNewBlock([]byte("genesis"), 0)
+
 	err = y.AddBlock(firstBlock)
 	assert.NoError(t, err)
 
@@ -295,6 +298,8 @@ func TestYggdrasil_GetBlockByTxID(t *testing.T) {
 	}()
 
 	firstBlock := getNewBlock([]byte("genesis"), 0)
+	fmt.Println("firstblock")
+	fmt.Println(firstBlock.PrevSeal)
 
 	err = y.AddBlock(firstBlock)
 	assert.NoError(t, err)
@@ -306,13 +311,18 @@ func TestYggdrasil_GetBlockByTxID(t *testing.T) {
 
 	//then
 	assert.Equal(t, firstBlock, retrievedBlock)
+
 }
 
 func getNewBlock(prevSeal []byte, height uint64) *impl.DefaultBlock {
 	validator := &impl.DefaultValidator{}
 	testingTime := getTime()
+	fmt.Println("testingTime:")
+	fmt.Println(testingTime)
 	blockCreator := []byte("testUser")
 	txList := getTxList(testingTime)
+	fmt.Println("Debugging")
+	fmt.Println(txList)
 
 	block := impl.NewEmptyBlock(prevSeal, height, blockCreator)
 	block.SetTimestamp(testingTime)


### PR DESCRIPTION
it-chain-Engine에서 Validator를 적용하기 위해 yggdrasill을 일부 수정하였습니다. 수정한 내용은 다음과 같습니다.
<수정 내용>
1.impl/default_validator.go:BuildSeal()
rootHash를 계산할 때, TxList에 트랜잭션이 없을 경우도 고려하기 위해 TxList가 비어있을 경우 빈 rootHash를 만들어주었습니다.

GenesisBlock에서 트랜잭션이 하나도 없을 수 있도록 하기 위해 수정한 것인데, rootHash가 빈 값이어도 되는 지 모르겠습니다. 일단 GenesisBlock에 자유도를 주겠다는 의도로 이렇게 수정한 것인데, 이론적으로 괜찮은 것인지 의견 부탁드립니다! rootHash값이 빈 값일 수 없다면 GenesisBlock의 자유도를 줄이더라도 default 트랜잭션을 넣어주겠습니다.

@byron1st