### PR TITLE
buildSeal change and other following changes

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -1,11 +1,13 @@
 package common
 
+import "time"
+
 // Validator 는 Block의 Transaction들이 위변조 되지 않고 처음 작성된대로 저장되었음을 검증해준다.
 // 위변조가 되지 않음을 증명하는 []byte 값을 Seal(인장)이라고 부르며, 흔히 Hash 값이 사용된다.
 // Default 구현체는 Merkle Tree를 기반으로 Seal을 만들고, 검증한다.
 type Validator interface {
 	// Seal들을 작성해주는 함수들
-	BuildSeal(block Block) ([]byte, error)
+	BuildSeal(timeStamp time.Time, prevSeal []byte, txSeal [][]byte, creator []byte) ([]byte, error)
 	BuildTxSeal(txList []Transaction) ([][]byte, error)
 
 	// Seal들을 검증해주는 함수들

--- a/impl/default_block_test.go
+++ b/impl/default_block_test.go
@@ -39,7 +39,7 @@ func getNewBlock() *DefaultBlock {
 	txSeal, _ := validator.BuildTxSeal(convertType(txList))
 	block.SetTxSeal(txSeal)
 
-	seal, _ := validator.BuildSeal(block)
+	seal, _ := validator.BuildSeal(block.GetTimestamp(), block.GetPrevSeal(), block.GetTxSeal(), block.GetCreator())
 	block.SetSeal(seal)
 
 	return block

--- a/yggdrasill.go
+++ b/yggdrasill.go
@@ -26,7 +26,7 @@ type BlockStorageManager interface {
 	Close()
 	GetValidator() common.Validator
 	AddBlock(block common.Block) error
-	GetBlockByHeight(block common.Block, blockHeight uint64) error
+	GetBlockByHeight(block common.Block, height uint64) error
 	GetBlockBySeal(block common.Block, seal []byte) error
 	GetBlockByTxID(block common.Block, txid string) error
 	GetLastBlock(block common.Block) error

--- a/yggdrasill_test.go
+++ b/yggdrasill_test.go
@@ -49,6 +49,7 @@ func TestYggdrasill_AddBlock_OneBlock(t *testing.T) {
 
 	lastBlock := &impl.DefaultBlock{}
 	err = y.GetLastBlock(lastBlock)
+
 	assert.NoError(t, err)
 
 	assert.Equal(t, firstBlock.GetHeight(), lastBlock.GetHeight())
@@ -320,7 +321,7 @@ func getNewBlock(prevSeal []byte, height uint64) *impl.DefaultBlock {
 	txSeal, _ := validator.BuildTxSeal(convertTxListType(txList))
 	block.SetTxSeal(txSeal)
 
-	seal, _ := validator.BuildSeal(block)
+	seal, _ := validator.BuildSeal(block.GetTimestamp(), block.GetPrevSeal(), block.GetTxSeal(), block.GetCreator())
 	block.SetSeal(seal)
 
 	return block


### PR DESCRIPTION
it-chain-engine 에서 **buildSeal 함수의 파라미터 값을 변경함**에 따라
Yggdrasill을 변경해 준 것입니다.

it-chain-engine에서 buildSeal 함수를 변경해준 이유는 다음과 같습니다.
1. 입력값에 block 구조체가 있을 경우, CreateBlock 시 Block객체에 의존하여 점차적으로 만들어져야 합니다. 반면 입력값을 세분화하면 CreateBlock 시 block 객체에 의존할 필요 없이 파라미터 값을 넣어줄 수 있습니다.
2. 입력값에 block 구조체를 넣을 경우 CreateBlock 테스트 시 코드가 지저분해지는 문제가 있었습니다. eventRepository에 Save하는 것을 테스트하고자 할 때, 예상되는 Seal과 출력되는 Seal이 같은 지 확인하기 위해 CreateBlock을 두번 해야했습니다. 

이러한 점들을 개선하기 위해 buildSeal 함수를 수정했습니다. 코멘트 부탁드립니다.
@byron1st 