### PR TITLE
convert creator : []byte to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ tx := NewDefaultTransaction(senderID, txID, time, txData)
 ```go
 prevBlockSeal := []byte{...}
 height := 0
-blockCreatorID := []byte{...}
+blockCreatorID := "hero"
 
 // Define new empty block
 block := NewEmptyBlock(prevBlockSeal, height, blockCreatorID)

--- a/common/block.go
+++ b/common/block.go
@@ -17,7 +17,7 @@ type Block interface {
 	SetHeight(height uint64)
 	PutTx(tx Transaction) error
 	SetTxSeal(txSeal [][]byte)
-	SetCreator(creator []byte)
+	SetCreator(creator string)
 	SetTimestamp(currentTime time.Time)
 
 	// Block의 required field getters
@@ -26,7 +26,7 @@ type Block interface {
 	GetHeight() uint64
 	GetTxList() []Transaction
 	GetTxSeal() [][]byte
-	GetCreator() []byte
+	GetCreator() string
 	GetTimestamp() time.Time
 
 	// Block을 저장을 위한 []byte로 변환 및 재변환

--- a/common/validator.go
+++ b/common/validator.go
@@ -7,7 +7,7 @@ import "time"
 // Default 구현체는 Merkle Tree를 기반으로 Seal을 만들고, 검증한다.
 type Validator interface {
 	// Seal들을 작성해주는 함수들
-	BuildSeal(timeStamp time.Time, prevSeal []byte, txSeal [][]byte, creator []byte) ([]byte, error)
+	BuildSeal(timeStamp time.Time, prevSeal []byte, txSeal [][]byte, creator string) ([]byte, error)
 	BuildTxSeal(txList []Transaction) ([][]byte, error)
 
 	// Seal들을 검증해주는 함수들

--- a/impl/default_block.go
+++ b/impl/default_block.go
@@ -15,7 +15,7 @@ type DefaultBlock struct {
 	TxList    []*DefaultTransaction
 	TxSeal    [][]byte
 	Timestamp time.Time
-	Creator   []byte
+	Creator   string
 }
 
 func (block *DefaultBlock) SetSeal(seal []byte) {
@@ -49,7 +49,7 @@ func (block *DefaultBlock) SetTxSeal(txSeal [][]byte) {
 	block.TxSeal = txSeal
 }
 
-func (block *DefaultBlock) SetCreator(creator []byte) {
+func (block *DefaultBlock) SetCreator(creator string) {
 	block.Creator = creator
 }
 
@@ -81,7 +81,7 @@ func (block *DefaultBlock) GetTxSeal() [][]byte {
 	return block.TxSeal
 }
 
-func (block *DefaultBlock) GetCreator() []byte {
+func (block *DefaultBlock) GetCreator() string {
 	return block.Creator
 }
 
@@ -121,7 +121,7 @@ func (block *DefaultBlock) IsPrev(serializedPrevBlock []byte) bool {
 	return bytes.Compare(prevBlock.GetSeal(), block.GetPrevSeal()) == 0
 }
 
-func NewEmptyBlock(prevSeal []byte, height uint64, creator []byte) *DefaultBlock {
+func NewEmptyBlock(prevSeal []byte, height uint64, creator string) *DefaultBlock {
 	block := &DefaultBlock{}
 
 	block.SetPrevSeal(prevSeal)

--- a/impl/default_block_test.go
+++ b/impl/default_block_test.go
@@ -27,7 +27,7 @@ func TestSerializeAndDeserialize(t *testing.T) {
 func getNewBlock() *DefaultBlock {
 	validator := &DefaultValidator{}
 	testingTime, _ := time.Parse("Jan 2, 2006 at 3:04pm (MST)", "Feb 3, 2013 at 7:54pm (UTC)")
-	blockCreator := []byte("testUser")
+	blockCreator := "testUser"
 	genesisSeal := []byte("genesis")
 	txList := getTestingTxList(0)
 	block := NewEmptyBlock(genesisSeal, 0, blockCreator)

--- a/impl/default_validator.go
+++ b/impl/default_validator.go
@@ -110,13 +110,13 @@ func (t *DefaultValidator) ValidateTransaction(txSeal [][]byte, transaction comm
 
 // BuildSeal 함수는 block 객체를 받아서 Seal 값을 만들고, Seal 값을 반환한다.
 // 인풋 파라미터의 block에 자동으로 할당해주지는 않는다.
-func (t *DefaultValidator) BuildSeal(timeStamp time.Time, prevSeal []byte, txSeal [][]byte, creator []byte) ([]byte, error) {
+func (t *DefaultValidator) BuildSeal(timeStamp time.Time, prevSeal []byte, txSeal [][]byte, creator string) ([]byte, error) {
 	timestamp, err := timeStamp.MarshalText()
 	if err != nil {
 		return nil, err
 	}
 
-	if prevSeal == nil || txSeal == nil || creator == nil {
+	if prevSeal == nil || txSeal == nil || creator == "" {
 		return nil, common.ErrInsufficientFields
 	}
 	var rootHash []byte

--- a/yggdrasill_test.go
+++ b/yggdrasill_test.go
@@ -7,7 +7,6 @@ import (
 
 	"time"
 
-	"github.com/it-chain/leveldb-wrapper"
 	"github.com/it-chain/yggdrasill/common"
 	"github.com/it-chain/yggdrasill/impl"
 	"github.com/stretchr/testify/assert"
@@ -55,7 +54,7 @@ func TestYggdrasill_AddBlock_OneBlock(t *testing.T) {
 	assert.Equal(t, firstBlock.GetHeight(), lastBlock.GetHeight())
 	assert.Equal(t, uint64(0), firstBlock.GetHeight())
 	assert.Equal(t, uint64(0), lastBlock.GetHeight())
-	assert.Equal(t, []byte("testUser"), lastBlock.GetCreator())
+	assert.Equal(t, "testUser", lastBlock.GetCreator())
 	assert.Equal(t, "tx01", lastBlock.GetTxList()[0].GetID())
 }
 
@@ -311,7 +310,7 @@ func TestYggdrasil_GetBlockByTxID(t *testing.T) {
 func getNewBlock(prevSeal []byte, height uint64) *impl.DefaultBlock {
 	validator := &impl.DefaultValidator{}
 	testingTime := getTime()
-	blockCreator := []byte("testUser")
+	blockCreator := "testUser"
 	txList := getTxList(testingTime)
 	block := impl.NewEmptyBlock(prevSeal, height, blockCreator)
 	block.SetTimestamp(testingTime)


### PR DESCRIPTION
releated issue: it-chain / engine #556 [link](https://github.com/it-chain/engine/issues/556)

fixed out Block.go Creator []byte to string.